### PR TITLE
Не задано умолчание для параметра $translit в функции sms_send в версии 1.3.0

### DIFF
--- a/lib/Zelenin/smsru.php
+++ b/lib/Zelenin/smsru.php
@@ -144,7 +144,7 @@ class smsru
 		$this->_params = $this->getAuthParams();
 	}
 
-	public function sms_send( $to, $text, $from = null, $time = null, $translit = false, $test = false, $partner_id = null )
+	public function sms_send( $to, $text, $from = null, $time = null, $translit, $test = false, $partner_id = null )
 	{
 		$url = self::HOST . self::SEND;
 		$params = $this->_params;
@@ -159,7 +159,7 @@ class smsru
 			$params['time'] = $time;
 		}
 
-		if ( $translit ) {
+		if ( $translit == 'true' ) {
 			$params['translit'] = 1;
 		}
 
@@ -190,7 +190,7 @@ class smsru
 		return $response;
 	}
 
-	public function multi_sms_send( $messages, $from = null, $time = null, $translit = false, $test = false, $partner_id = null )
+	public function multi_sms_send( $messages, $from = null, $time = null, $translit, $test = false, $partner_id = null )
 	{
 		$url = self::HOST . self::SEND;
 		$params = $this->_params;
@@ -207,7 +207,7 @@ class smsru
 			$params['time'] = $time;
 		}
 
-		if ( $translit ) {
+		if ( $translit == 'true' ) {
 			$params['translit'] = 1;
 		}
 


### PR DESCRIPTION
По Issue https://github.com/zelenin/sms_ru/issues/6
