### PR TITLE
Add $smsId in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,8 @@ $client->smsSend(new \Zelenin\SmsRu\Entity\SmsPool([$sms1, $sms2]));
 Статус SMS:
 
 ```php
+$send = $client->smsSend($sms);
+$smsId = $send->ids[0];
 $client->smsStatus($smsId);
 ```
 


### PR DESCRIPTION
It is not clear where to get the $smsId in order to check the status of SMS sending. I'd rather provide the description of this variable. 