### PR TITLE
Добавлен функционал отправки авторизационного кода звонком

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -10,6 +10,7 @@ use Zelenin\SmsRu\Entity\SmsPool;
 use Zelenin\SmsRu\Entity\StoplistPhone;
 use Zelenin\SmsRu\Exception\Exception;
 use Zelenin\SmsRu\Response\AuthCheckResponse;
+use Zelenin\SmsRu\Response\CallCodeResponse;
 use Zelenin\SmsRu\Response\MyBalanceResponse;
 use Zelenin\SmsRu\Response\MyLimitResponse;
 use Zelenin\SmsRu\Response\MySendersResponse;
@@ -261,6 +262,21 @@ class Api
         }
 
         return $stoplistGetResponse;
+    }
+
+    public function codeCall($phone)
+    {
+        $params = array_merge(['phone' => $phone], $this->getAuth()->getAuthParams());
+        $response = $this->client->request('code/call', $params);
+
+        $json = json_decode($response, true);
+
+        if (is_array($json) == false) {
+            $response = explode("\n", $response);
+            return new CallCodeResponse(array_shift($response));
+        }
+
+        return CallCodeResponse::makeByJson($json);
     }
 
     /**

--- a/Response/CallCodeResponse.php
+++ b/Response/CallCodeResponse.php
@@ -17,7 +17,7 @@ class CallCodeResponse extends AbstractResponse
     public $callId;
 
     protected $availableDescriptions = [
-        '100' => 'Запрос выполнен. На второй строчке вы найдете ваше текущее дневное ограничение. На третьей строчке количество сообщений, отправленных вами в текущий день.',
+        '100' => 'Запрос выполнен.',
         '200' => 'Неправильный api_id.',
         '210' => 'Используется GET, где необходимо использовать POST.',
         '211' => 'Метод не найден.',
@@ -30,9 +30,11 @@ class CallCodeResponse extends AbstractResponse
     public static function makeByJson(array $json)
     {
         if ($json['status'] == 'ERROR') {
-            $errorCode = '400';
-            $response = new CallCodeResponse($errorCode);
-            $response->availableDescriptions[$errorCode] = $json['status_text'];
+            $code = '400';
+
+            $response = new CallCodeResponse($code);
+            $response->availableDescriptions[$code] = $json['status_text'];
+
             return $response;
         }
 

--- a/Response/CallCodeResponse.php
+++ b/Response/CallCodeResponse.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Zelenin\SmsRu\Response;
+
+class CallCodeResponse extends AbstractResponse
+{
+    /** @var int|null */
+    public $checkCode;
+
+    /** @var float|null */
+    public $balance;
+
+    /** @var float|null */
+    public $cost;
+
+    /** @var string|null */
+    public $callId;
+
+    protected $availableDescriptions = [
+        '100' => 'Запрос выполнен. На второй строчке вы найдете ваше текущее дневное ограничение. На третьей строчке количество сообщений, отправленных вами в текущий день.',
+        '200' => 'Неправильный api_id.',
+        '210' => 'Используется GET, где необходимо использовать POST.',
+        '211' => 'Метод не найден.',
+        '220' => 'Сервис временно недоступен, попробуйте чуть позже.',
+        '300' => 'Неправильный token (возможно истек срок действия, либо ваш IP изменился).',
+        '301' => 'Неправильный пароль, либо пользователь не найден.',
+        '302' => 'Пользователь авторизован, но аккаунт не подтвержден (пользователь не ввел код, присланный в регистрационной смс).',
+    ];
+
+    public static function makeByJson(array $json)
+    {
+        if ($json['status'] == 'ERROR') {
+            $errorCode = '400';
+            $response = new CallCodeResponse($errorCode);
+            $response->availableDescriptions[$errorCode] = $json['status_text'];
+            return $response;
+        }
+
+        $response = new CallCodeResponse('100');
+
+        $response->checkCode = $json['code'];
+        $response->balance = $json['balance'];
+        $response->cost = $json['cost'];
+        $response->callId = $json['call_id'];
+
+        return $response;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require": {
         "php": ">=5.5.0",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "~6 || ~7"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,13 @@ $client->stoplistDel($phone);
 $client->stoplistGet();
 ```
 
+Отправить четырехзначный авторизационный код звонком:
+
+```php
+$response = $client->codeCall($phone);
+echo $response->checkCode;
+```
+
 ## Автор
 
 [Александр Зеленин](https://github.com/zelenin/), e-mail: [aleksandr@zelenin.me](mailto:aleksandr@zelenin.me)


### PR DESCRIPTION
На сколько я понимаю, все Response-классы работали с не-json ответами. Но метод звонка возвращает возвращает и json, и просто text, в зависимости от самого ответа. Например в случае успешного ответа:

```
{
    "status": "OK",
    "code": "1435",
    "call_id": "000000-10000000",
    "cost": 0.4,
    "balance": 4122.56
}
```

Если указать не валидный номер телефона, то: 
```
{
    "status": "ERROR",
    "status_text": "Номер указан неверно"
}
```

А если не указать токен/логин пароль, то ответ будет такой:
```
"301\n
"
```